### PR TITLE
Add user-agent to urllib2 to fix 403s

### DIFF
--- a/campbx/campbx.py
+++ b/campbx/campbx.py
@@ -13,6 +13,10 @@ log_handler.setFormatter(log_formatter)
 log.addHandler(log_handler)
 log.setLevel(logging.ERROR)
 
+opener = urllib2.build_opener()
+opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+urllib2.install_opener(opener)
+
 
 class EndPointPartial(partial):
     def __new__(cls, func, conf, _repr):


### PR DESCRIPTION
Apparently CampBX API requires a browser-like User-agent string, or else throws a 403 for all requests. Add one. (I'm guessing this is a server-side change?)

Something like: http://stackoverflow.com/questions/14471212/why-is-pythons-urllib2-urlopen-giving-me-a-403-error
